### PR TITLE
Fixing of README and fits_dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,11 @@ To run locally for development.
 
 ## Running
 
-1. Start a local server, e.g. `python -m SimpleHTTPServer`
-2. Incase you want auto reload install live-server  `npm install -g live-server` and run `live-server ./`
+1. If you want to run the app locally and debug or test it. It is advisable to serve the index.html found in the root of your project.
+2. The build directory is a compressed and uglified version of the app to be used for production deployment of the app for fast network performances.
+3. Serve the app by running a local server, e.g. `python -m SimpleHTTPServer`
+4. Incase you want auto reload install live-server  `npm install -g live-server` and run `live-server ./`
+
 
 ## Deploying
 

--- a/fits_dump.py
+++ b/fits_dump.py
@@ -1,3 +1,6 @@
+"""
+Dump FITS format data to JSON format for display on website.
+"""
 import json
 import click
 from astropy.table import Table


### PR DESCRIPTION
@cdeil I am so sorry for the ambiguity in the README.
So the index.html in the root of project is the one used to running locally for development, and the build folder is for the compressed version _(similar to an executable)_ for production environment.

And also I want to know if you were able to setup this project. Was JSPM installed successfully ? 
