### PR TITLE
Adding more cols to table

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -20,7 +20,6 @@ export default class App extends Component {
     this.catalog = '2fhl';
   }
   sourceNameChange(e) {
-    console.log('changed',e);
     this.setState({
       sourceName: e,
     });
@@ -29,16 +28,18 @@ export default class App extends Component {
     return (
       <div className="app">
         <Navbar/>
-        <Col md={2} className="sidebar">
-          <LeftPane catalog={this.catalog}
-            data={this.data}
-            sourceName={this.state.sourceName}
-            sourceNameChange={this.sourceNameChange}
-          />
-        </Col>
-        <Col md={8} mdOffset={3}>
-          <Content sourceName={this.state.sourceName} data={this.data}/>
-        </Col>
+        <div style={{ marginTop: '80px' }}>
+          <Col md={2} className="sidebar">
+            <LeftPane catalog={this.catalog}
+              data={this.data}
+              sourceName={this.state.sourceName}
+              sourceNameChange={this.sourceNameChange}
+            />
+          </Col>
+          <Col md={8} mdOffset={3}>
+            <Content sourceName={this.state.sourceName} data={this.data}/>
+          </Col>
+        </div>
         <Footer/>
       </div>
     );

--- a/app/components/Navbar.js
+++ b/app/components/Navbar.js
@@ -8,7 +8,7 @@ const style = {
 
 export default () => {
   return (
-    <Navbar inverse style={style}>
+    <Navbar inverse style={style} className="navbar-fixed-top">
       <Navbar.Header>
         <Navbar.Brand>
           <a href="#">Gammapy Catalog Browser</a>

--- a/fits_dump.py
+++ b/fits_dump.py
@@ -12,7 +12,45 @@ def _dump_json(data, filename):
         fh.write('\n')
 
 table = Table.read('https://github.com/gammapy/gammapy-extra/blob/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz?raw=true')
-cols = ['Source_Name', 'RAJ2000', 'DEJ2000', 'GLON', 'GLAT', 'CLASS']
+cols = ['Source_Name',
+        'RAJ2000',
+        'DEJ2000',
+        'GLON',
+        'GLAT',
+        'Pos_err_68',
+        'TS',
+        'Spectral_Index',
+        'Unc_Spectral_Index',
+        'Intr_Spectral_Index_D11',
+        'Unc_Intr_Spectral_Index_D11',
+        'Intr_Spectral_Index_G12',
+        'Unc_Intr_Spectral_Index_G12',
+        'Flux50',
+        'Unc_Flux50',
+        'Energy_Flux50',
+        'Unc_Energy_Flux50',
+        'Flux50_171GeV',
+        'Unc_Flux50_171GeV',
+        'Sqrt_TS50_171GeV',
+        'Flux171_585GeV',
+        'Unc_Flux171_585GeV',
+        'Sqrt_TS171_585GeV',
+        'Flux585_2000GeV',
+        'Unc_Flux585_2000GeV',
+        'Sqrt_TS585_2000GeV',
+        'Npred',
+        'HEP_Energy',
+        'HEP_Prob',
+        'ROI',
+        'ASSOC',
+        'ASSOC_PROB_BAY',
+        'ASSOC_PROB_LR',
+        'CLASS',
+        'Redshift',
+        'NuPeak_obs',
+        '3FGL_Name',
+        '1FHL_Name',
+        'TeVCat_Name']
 df = table[cols].to_pandas()
 data = df.to_json()
 


### PR DESCRIPTION
In ref to issue #5 , I tried to manually add the columns but the script throws error

``` shell
Downloading https://github.com/gammapy/gammapy-extra/blob/master/datasets/catalogs/fermi/gll_psch_v08.fit.gz?raw=true
|==========================================| 205k/205k (100.00%)         0s
WARNING: hdu= was not specified but multiple tables are present, reading in first available table (hdu=1) [astropy.io.fits.connect]
WARNING: UnitsWarning: 'photon/cm**2/s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
WARNING: UnitsWarning: The unit 'erg' has been deprecated in the FITS standard. Suggested: cm2 g s-2. [astropy.units.format.utils]
WARNING: UnitsWarning: 'erg/cm**2/s' contains multiple slashes, which is discouraged by the FITS standard [astropy.units.format.generic]
Traceback (most recent call last):
  File "fits_dump.py", line 54, in <module>
    df = table[cols].to_pandas()
  File "/Users/kushanjoshi/anaconda/lib/python3.5/site-packages/astropy/table/table.py", line 2418, in to_pandas
    raise ValueError("Cannot convert a table with multi-dimensional columns to a pandas DataFrame")
ValueError: Cannot convert a table with multi-dimensional columns to a pandas DataFrame
```
